### PR TITLE
refactor(types): rework all types 

### DIFF
--- a/src/data/quotes.ts
+++ b/src/data/quotes.ts
@@ -1,9 +1,9 @@
-import type { Quote } from "../types/index.js"
+import type { QuoteCreation } from "../types/quote.js"
 
 /**
  * Initial quotes data
  */
-export const quotes: Quote[] = [
+export const quotes: QuoteCreation[] = [
   {
     author: "Steve Jobs",
     categories: ["Work"],

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,20 @@
+/**
+ * Defines the structure of a validation error
+ *
+ * @typeParam Expected - The expected value type
+ * @typeParam Received - The received value type
+ */
 export type ValidationError<Expected = string, Received = unknown> = {
+  /**
+   * The expected type
+   */
   expected: Expected
+  /**
+   * The error message
+   */
   message: string
+  /**
+   * The received value
+   */
   received: Received
 }

--- a/src/types/quote.ts
+++ b/src/types/quote.ts
@@ -1,27 +1,59 @@
-export type Category =
-  | "Art"
-  | "Fashion"
-  | "Funny"
-  | "Inspirational"
-  | "Leadership"
-  | "Life"
-  | "Love"
-  | "Motivational"
-  | "Music"
-  | "People"
-  | "Sports"
-  | "Success"
-  | "Wisdom"
-  | "Work"
+import type { Quote as PrismaQuote } from "@prisma/client"
 
-export type Quote = {
+/**
+ * Defines the structure of a quote before it is added to the database
+ */
+export type QuoteCreation = {
+  /**
+   * The author of the quote
+   */
   author?: string
-  categories: Category[]
+  /**
+   * The categories the quote belongs in
+   */
+  categories: string[]
+  /**
+   * The submitter of the quote
+   */
   submitter: string
+  /**
+   * The text of the quote
+   */
   text: string
+  /**
+   * Whether the quote is verified or not
+   */
   verified: boolean
 }
 
-export type QuoteWithStringCategories = Omit<Quote, "categories"> & { categories: string }
+/**
+ * Defines the structure of a quote after it is added to the database
+ */
+export type DatabaseQuote = Omit<QuoteCreation, "categories"> & {
+  /**
+   * The categories the quote belongs in
+   */
+  categories: PrismaQuote["categories"]
+  /**
+   * The date the quote was submitted
+   */
+  createdAt: PrismaQuote["createdAt"]
+  /**
+   * The Id of the quote
+   */
+  id: PrismaQuote["id"]
+  /**
+   * The date the quote was last updated
+   */
+  updatedAt: PrismaQuote["updatedAt"]
+}
 
-export type QuoteUnion = Quote | QuoteWithStringCategories
+/**
+ * Defines the structure of a quote with categories as an array
+ */
+export type QuoteWithCategoriesArray = Omit<DatabaseQuote, "categories"> & Pick<QuoteCreation, "categories">
+
+/**
+ * Defined a union of a quote before and after it is added to the database
+ */
+export type QuoteUnion = DatabaseQuote | QuoteCreation

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,6 +1,5 @@
-import type { Quote as DatabaseQuote } from "@prisma/client"
 import Filter from "bad-words"
-import type { Category, QuoteUnion, ValidationError } from "../types/index.js"
+import type { DatabaseQuote, QuoteUnion, QuoteWithCategoriesArray, ValidationError } from "../types/index.js"
 
 /**
  * Converts the properties of a quote for the database
@@ -20,10 +19,10 @@ export function convertPropertiesForDatabase(quote: QuoteUnion) {
  *
  * @param quote - The quote to convert the properties of
  */
-export function convertPropertiesFromDatabase(quote: DatabaseQuote) {
+export function convertPropertiesFromDatabase(quote: DatabaseQuote): QuoteWithCategoriesArray {
   return {
     ...quote,
-    categories: typeof quote.categories === "string" ? (quote.categories.split(", ") as Category[]) : quote.categories,
+    categories: typeof quote.categories === "string" ? quote.categories.split(", ") : quote.categories,
   }
 }
 


### PR DESCRIPTION
As of #6, the `categories` property is simply an array of string to avoid complexity. This PR removes the `Category` type as it is no longer needed. It also reworks the quote and error types entirely to be easily understandable and well-documented.